### PR TITLE
Resolve issue HUDSON-1379

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,8 @@ THE SOFTWARE.
         <compileSource>1.6</compileSource>
         <maven-surefire-plugin.version>2.8.1</maven-surefire-plugin.version>
         <maven-pmd-plugin.version>2.5</maven-pmd-plugin.version>
+        <maven-gpg-plugin.version>1.2</maven-gpg-plugin.version>
+        <easymock.version>3.0</easymock.version>
     </properties>
 
     <dependencies>
@@ -61,7 +63,7 @@ THE SOFTWARE.
             <groupId>org.jvnet.hudson.main</groupId>
             <artifactId>hudson-test-harness</artifactId>
             <scope>test</scope>
-            <version>${parent.version}</version>
+            <version>${project.parent.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.jvnet.hudson.plugins</groupId>
@@ -73,7 +75,7 @@ THE SOFTWARE.
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>
             <scope>test</scope>
-            <version>3.0</version>
+            <version>${easymock.version}</version>
         </dependency>
     </dependencies>
 
@@ -135,7 +137,7 @@ THE SOFTWARE.
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.2</version>
+                        <version>${maven-gpg-plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>

--- a/src/main/java/hudson/scm/credential/PasswordCredential.java
+++ b/src/main/java/hudson/scm/credential/PasswordCredential.java
@@ -1,0 +1,76 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2011, Oracle Corporation, Nikita Levyankov
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.scm.credential;
+
+import hudson.scm.SubversionSCM;
+import hudson.util.Scrambler;
+import org.tmatesoft.svn.core.auth.ISVNAuthenticationManager;
+import org.tmatesoft.svn.core.auth.SVNAuthentication;
+import org.tmatesoft.svn.core.auth.SVNPasswordAuthentication;
+import org.tmatesoft.svn.core.auth.SVNSSHAuthentication;
+
+/**
+ * Username/password based authentication.
+ * <p/>
+ * Date: 5/11/11
+ *
+ * @author Nikita Levyankov
+ */
+public class PasswordCredential extends SubversionSCM.DescriptorImpl.Credential {
+    private final String userName;
+    private final String password; // scrambled by base64
+
+    public PasswordCredential(String userName, String password) {
+        this.userName = userName;
+        this.password = Scrambler.scramble(password);
+    }
+
+    @Override
+    public SVNAuthentication createSVNAuthentication(String kind) {
+        if (kind.equals(ISVNAuthenticationManager.SSH)) {
+            return new SVNSSHAuthentication(userName, Scrambler.descramble(password), -1, false);
+        } else {
+            return new SVNPasswordAuthentication(userName, Scrambler.descramble(password), false);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PasswordCredential that = (PasswordCredential) o;
+        return userName.equals(that.userName) && password.equals(that.password);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = userName.hashCode();
+        result = 31 * result + password.hashCode();
+        return result;
+    }
+}

--- a/src/main/java/hudson/scm/credential/SshPublicKeyCredential.java
+++ b/src/main/java/hudson/scm/credential/SshPublicKeyCredential.java
@@ -1,0 +1,153 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2011, Oracle Corporation, Nikita Levyankov
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.scm.credential;
+
+import hudson.model.Hudson;
+import hudson.remoting.Callable;
+import hudson.remoting.Channel;
+import hudson.scm.SubversionSCM;
+import hudson.util.Scrambler;
+import java.io.File;
+import java.io.IOException;
+import java.util.Random;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.apache.commons.io.FileUtils;
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.Project;
+import org.apache.tools.ant.taskdefs.Chmod;
+import org.tmatesoft.svn.core.SVNErrorCode;
+import org.tmatesoft.svn.core.SVNErrorMessage;
+import org.tmatesoft.svn.core.SVNException;
+import org.tmatesoft.svn.core.auth.ISVNAuthenticationManager;
+import org.tmatesoft.svn.core.auth.SVNSSHAuthentication;
+
+/**
+ * Public key authentication for Subversion over SSH.
+ * <p/>
+ * Date: 5/11/11
+ *
+ * @author Nikita Levyankov
+ */
+public class SshPublicKeyCredential extends SubversionSCM.DescriptorImpl.Credential {
+    private static final Logger LOGGER = Logger.getLogger(SubversionSCM.class.getName());
+    private final String userName;
+    private final String passphrase; // scrambled by base64
+    private final String id;
+
+    /**
+     * @param keyFile stores SSH private key. The file will be copied.
+     */
+    public SshPublicKeyCredential(String userName, String passphrase, File keyFile) throws SVNException {
+        this.userName = userName;
+        this.passphrase = Scrambler.scramble(passphrase);
+
+        Random r = new Random();
+        StringBuilder buf = new StringBuilder();
+        for (int i = 0; i < 16; i++) {
+            buf.append(Integer.toHexString(r.nextInt(16)));
+        }
+        this.id = buf.toString();
+
+        try {
+            File savedKeyFile = getKeyFile();
+            FileUtils.copyFile(keyFile, savedKeyFile);
+            setFilePermissions(savedKeyFile, "600");
+        } catch (IOException e) {
+            throw new SVNException(
+                SVNErrorMessage.create(SVNErrorCode.AUTHN_CREDS_UNAVAILABLE,
+                    Messages.SshPublicKeyCredential_private_key_save_error()), e);
+        }
+    }
+
+    /**
+     * Gets the location where the private key will be permanently stored.
+     */
+    private File getKeyFile() {
+        File dir = new File(Hudson.getInstance().getRootDir(),
+            Messages.SshPublicKeyCredential_private_key());
+        if (dir.mkdirs()) {
+            // make sure the directory exists. if we created it, try to set the permission to 600
+            // since this is sensitive information
+            setFilePermissions(dir,
+                Messages.SshPublicKeyCredential_private_key_permissions());
+        }
+        return new File(dir, id);
+    }
+
+    /**
+     * Set the file permissions
+     */
+    private boolean setFilePermissions(File file, String perms) {
+        try {
+            Chmod chmod = new Chmod();
+            chmod.setProject(new Project());
+            chmod.setFile(file);
+            chmod.setPerm(perms);
+            chmod.execute();
+        } catch (BuildException e) {
+            // if we failed to set the permission, that's fine.
+            LOGGER.log(Level.WARNING,
+                Messages.SshPublicKeyCredential_private_key_set_permissions_error(file), e);
+            return false;
+        }
+
+        return true;
+    }
+
+
+    @Override
+    public SVNSSHAuthentication createSVNAuthentication(String kind) throws SVNException {
+        if (kind.equals(ISVNAuthenticationManager.SSH)) {
+            try {
+                Channel channel = Channel.current();
+                String privateKey;
+                if (channel != null) {
+                    // remote
+                    privateKey = channel.call(new Callable<String, IOException>() {
+                        public String call() throws IOException {
+                            return FileUtils.readFileToString(getKeyFile(),
+                                Messages.SshPublicKeyCredential_private_key_encoding());
+                        }
+                    });
+                } else {
+                    privateKey = FileUtils.readFileToString(getKeyFile(),
+                        Messages.SshPublicKeyCredential_private_key_encoding());
+                }
+                return new SVNSSHAuthentication(userName, privateKey.toCharArray(),
+                    Scrambler.descramble(passphrase), -1, false);
+            } catch (IOException e) {
+                throw new SVNException(
+                    SVNErrorMessage.create(SVNErrorCode.AUTHN_CREDS_UNAVAILABLE,
+                        Messages.SshPublicKeyCredential_private_key_load_error()), e);
+            } catch (InterruptedException e) {
+                throw new SVNException(
+                    SVNErrorMessage.create(SVNErrorCode.AUTHN_CREDS_UNAVAILABLE,
+                        Messages.SshPublicKeyCredential_private_key_load_error()), e);
+            }
+        } else {
+            return null; // unknown
+        }
+    }
+}

--- a/src/main/java/hudson/scm/credential/SslClientCertificateCredential.java
+++ b/src/main/java/hudson/scm/credential/SslClientCertificateCredential.java
@@ -1,0 +1,68 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2011, Oracle Corporation, Nikita Levyankov
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.scm.credential;
+
+import com.trilead.ssh2.crypto.Base64;
+import hudson.scm.SubversionSCM;
+import hudson.util.Scrambler;
+import hudson.util.Secret;
+import java.io.File;
+import java.io.IOException;
+import org.apache.commons.io.FileUtils;
+import org.tmatesoft.svn.core.auth.ISVNAuthenticationManager;
+import org.tmatesoft.svn.core.auth.SVNAuthentication;
+import org.tmatesoft.svn.core.auth.SVNSSLAuthentication;
+
+/**
+ * SSL client certificate based authentication.
+ * <p/>
+ * Date: 5/11/11
+ *
+ * @author Nikita Levyankov
+ */
+public class SslClientCertificateCredential extends SubversionSCM.DescriptorImpl.Credential {
+    private final Secret certificate;
+    private final String password; // scrambled by base64
+
+    public SslClientCertificateCredential(File certificate, String password) throws IOException {
+        this.password = Scrambler.scramble(password);
+        this.certificate = Secret.fromString(
+            new String(Base64.encode(FileUtils.readFileToByteArray(certificate))));
+    }
+
+    @Override
+    public SVNAuthentication createSVNAuthentication(String kind) {
+        if (kind.equals(ISVNAuthenticationManager.SSL)) {
+            try {
+                return new SVNSSLAuthentication(
+                    Base64.decode(certificate.getPlainText().toCharArray()),
+                    Scrambler.descramble(password), false);
+            } catch (IOException e) {
+                throw new Error(e); // can't happen
+            }
+        } else {
+            return null; // unexpected authentication type
+        }
+    }
+}

--- a/src/main/resources/hudson/scm/SubversionSCM/DescriptorImpl/enterCredential.jelly
+++ b/src/main/resources/hudson/scm/SubversionSCM/DescriptorImpl/enterCredential.jelly
@@ -22,29 +22,32 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <l:layout norefresh="true" title="${%Subversion Authentication}">
-    <l:header />
-    <l:side-panel />
-    <l:main-panel>
-      <h1>
-        <img src="${imagesURL}/48x48/secure.gif" width="48" height="48" alt=""/>
-        ${%Subversion Authentication}
-      </h1>
-      <p>
-        ${%description}
-      </p>
-      <f:form method="post" action="postCredential" enctype="multipart/form-data" name="postCredential">
-        <f:entry title="${%Repository URL}">
-          <f:textbox name="url" value="${request.queryString}" />
-        </f:entry>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+    <l:layout norefresh="true" title="${%Subversion Authentication}">
+        <l:header/>
+        <l:side-panel/>
+        <l:main-panel>
+            <h1>
+                <img src="${imagesURL}/48x48/secure.gif" width="48" height="48" alt=""/>
+                ${%Subversion Authentication}
+            </h1>
+            <p>
+                ${%description}
+            </p>
+            <f:form method="post" action="postCredential" enctype="multipart/form-data" name="postCredential">
+                <f:entry title="${%Repository URL}">
+                    <f:textbox name="url" value="${request.queryString}"/>
+                </f:entry>
 
-        <enterCredential xmlns="/hudson/scm/subversion" />
-
-        <f:block>
-          <f:submit value="${%OK}" style="margin-top:1em;" />
-        </f:block>
-      </f:form>
-    </l:main-panel>
-  </l:layout>
+                <enterCredential xmlns="/hudson/scm/subversion"/>
+                <f:entry title="${%Override global credentials}">
+                    <f:booleanRadio field="overrideGlobal"/>
+                </f:entry>
+                <f:block>
+                    <f:submit value="${%OK}" style="margin-top:1em;"/>
+                </f:block>
+            </f:form>
+        </l:main-panel>
+    </l:layout>
 </j:jelly>


### PR DESCRIPTION
Introduce credentials package and simplify logic. Implement ability to set different credentials for one subversion realm repository. Add ability to override global credentials by user choise. Update and clean-up code

http://issues.hudson-ci.org/browse/HUDSON-1379
