### PR TITLE
Fix for HUDSON-8841 Setting SVN credentials for a job should not require administer permission.

### DIFF
--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -42,7 +42,6 @@ import hudson.model.BuildListener;
 import hudson.model.Computer;
 import hudson.model.Hudson;
 import hudson.model.Hudson.MasterComputer;
-import hudson.model.Item;
 import hudson.model.Node;
 import hudson.model.ParametersAction;
 import hudson.model.Run;
@@ -1731,9 +1730,6 @@ public class SubversionSCM extends SCM implements Serializable {
          */
         // TODO: stapler should do multipart/form-data handling
         public void doPostCredential(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
-            //User should have Configure permissions.
-            Hudson.getInstance().checkPermission(Item.CONFIGURE);
-
             MultipartFormDataParser parser = new MultipartFormDataParser(req);
 
             // we'll record what credential we are trying here.


### PR DESCRIPTION
Fix for HUDSON-8841 Setting SVN credentials for a job should not require administer permission.
