### PR TITLE
Fixed HUDSON-8700 Excluded Users field with subversion doesn't accept users with dash (-) in name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@ THE SOFTWARE.
     <parent>
         <groupId>org.jvnet.hudson.plugins</groupId>
         <artifactId>hudson-plugin-parent</artifactId>
-        <version>2.0.1</version>
+        <version>2.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -36,7 +36,7 @@ THE SOFTWARE.
     <packaging>hpi</packaging>
     <name>Hudson Subversion Plug-in</name>
     <description>Integrates Hudson with Subversion SCM</description>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <url>http://wiki.hudson-ci.org/display/HUDSON/Subversion+Plugin</url>
     <licenses>
         <license>
@@ -62,7 +62,7 @@ THE SOFTWARE.
         </dependency>
         <dependency>
             <groupId>org.jvnet.hudson.main</groupId>
-            <artifactId>hudson-test-harness</artifactId>
+            <artifactId>hudson-test-framework</artifactId>
             <scope>test</scope>
             <version>${project.parent.version}</version>
             <exclusions>

--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -2026,9 +2026,9 @@ public class SubversionSCM extends SCM implements Serializable {
 
         /**
          * Regular expression for matching one username. Matches 'windows' names ('DOMAIN&#92;user') and
-         * 'normal' names ('user'). Where user (and DOMAIN) has one or more characters in 'a-zA-Z_0-9')
+         * 'normal' names ('user'). Where user (and DOMAIN) has one or more characters in 'a-zA-Z_0-9-.')
          */
-        private static final Pattern USERNAME_PATTERN = Pattern.compile("(\\w+\\\\)?+(\\w+)");
+        private static final Pattern USERNAME_PATTERN = Pattern.compile("(\\w+\\\\)?+((\\w|[-\\.])+)");
 
         /**
          * Validates the excludeUsers field.
@@ -2046,7 +2046,7 @@ public class SubversionSCM extends SCM implements Serializable {
                     continue;
                 }
 
-                if (!USERNAME_PATTERN.matcher(user).matches()) {
+                if (!validateExcludedUser(user)) {
                     return FormValidation.error("Invalid username: " + user);
                 }
             }
@@ -2134,6 +2134,15 @@ public class SubversionSCM extends SCM implements Serializable {
             new Initializer();
         }
 
+        /**
+         * Validates the excluded user name.
+         *
+         * @param value value to validate.
+         * @return true if user name is valid.
+         */
+        static boolean validateExcludedUser(String value) {
+            return USERNAME_PATTERN.matcher(value).matches();
+        }
     }
 
     public boolean repositoryLocationsNoLongerExist(AbstractBuild<?, ?> build, TaskListener listener) {
@@ -2173,6 +2182,7 @@ public class SubversionSCM extends SCM implements Serializable {
     static {
         new Initializer();
     }
+
 
     private static final class Initializer {
         static {

--- a/src/test/java/hudson/scm/SubversionCheckoutTest.java
+++ b/src/test/java/hudson/scm/SubversionCheckoutTest.java
@@ -195,7 +195,9 @@ public class SubversionCheckoutTest extends AbstractSubversionTest {
                 "user123",
                 "User",
                 "", // this one is ignored
-                "DOmain12\\User34"};
+                "DOmain12\\User34",
+                "DOMAIN.user",
+                "continuous-habbo"};
 
         for (String validUsername : validUsernames) {
             assertEquals(
@@ -207,8 +209,7 @@ public class SubversionCheckoutTest extends AbstractSubversionTest {
         String[] invalidUsernames = new String[]{
                 "\\user",
                 "DOMAIN\\",
-                "DOMAIN@user",
-                "DOMAIN.user"};
+                "DOMAIN@user"};
 
         for (String invalidUsername : invalidUsernames) {
             assertEquals(

--- a/src/test/java/hudson/scm/SubversionSCMTest.java
+++ b/src/test/java/hudson/scm/SubversionSCMTest.java
@@ -1,0 +1,67 @@
+/*
+  * The MIT License
+  *
+  * Copyright (c) 2011, Oracle Corporation
+  *
+  * Permission is hereby granted, free of charge, to any person obtaining a copy
+  * of this software and associated documentation files (the "Software"), to deal
+  * in the Software without restriction, including without limitation the rights
+  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  * copies of the Software, and to permit persons to whom the Software is
+  * furnished to do so, subject to the following conditions:
+  *
+  * The above copyright notice and this permission notice shall be included in
+  * all copies or substantial portions of the Software.
+  *
+  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  * THE SOFTWARE.
+  */
+
+package hudson.scm;
+
+import java.util.Arrays;
+import java.util.Collection;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.jvnet.hudson.test.Bug;
+
+
+/**
+ * Test for {@link SubversionSCM}
+ * </p>
+ * Date: 7/21/11
+ *
+ * @author
+ */
+@RunWith(Parameterized.class)
+public class SubversionSCMTest {
+
+    private String userName;
+    private boolean expectedResult;
+
+    public SubversionSCMTest(String userName, boolean expectedResult) {
+        this.userName = userName;
+        this.expectedResult = expectedResult;
+    }
+
+    @Parameterized.Parameters
+    public static Collection generateData() {
+        return Arrays.asList(new Object[][]{
+            {"user", true}, {"user-123", true}, {"user_123", true}, {"domain\\user-123", true},
+            {"user\\", false}, {"user[]", false}
+        });
+    }
+
+    @Bug(8700)
+    @Test
+    public void testValidateExcludedUsers() {
+        Assert.assertEquals(expectedResult, SubversionSCM.DescriptorImpl.validateExcludedUser(userName));
+    }
+}


### PR DESCRIPTION
Fixed HUDSON-8700 Excluded Users field with subversion doesn't accept users with dash (-) in name
