### PR TITLE
Fixed HUDSON-8554 SCM polling always return true when using specific revision in svn

### DIFF
--- a/src/main/java/hudson/scm/util/RevisionUtil.java
+++ b/src/main/java/hudson/scm/util/RevisionUtil.java
@@ -16,7 +16,7 @@ import org.tmatesoft.svn.core.wc.SVNRevision;
  */
 public final class RevisionUtil {
 
-    static final char AT_SYMBOL = '@';
+    public static final char AT_SYMBOL = '@';
 
     /**
      * Private constructor.

--- a/src/test/java/hudson/scm/SubversionCommitTest.java
+++ b/src/test/java/hudson/scm/SubversionCommitTest.java
@@ -273,29 +273,6 @@ public class SubversionCommitTest extends AbstractSubversionTest {
     }
 
     /**
-     * Do the polling on the slave and make sure it works.
-     */
-    @Bug(4299)
-    public void testPolling() throws Exception {
-//        SLAVE_DEBUG_PORT = 8001;
-        File repo = new CopyExisting(getClass().getResource("two-revisions.zip")).allocate();
-        SubversionSCM scm = new SubversionSCM("file://" + repo.getPath());
-
-        FreeStyleProject p = createFreeStyleProject();
-        p.setScm(scm);
-        p.setAssignedLabel(createSlave().getSelfLabel());
-        assertBuildStatusSuccess(p.scheduleBuild2(0).get());
-
-        // initial polling on the slave for the code path that doesn't find any change
-        assertFalse(p.pollSCMChanges(new StreamTaskListener(System.out, Charset.defaultCharset())));
-
-        createCommit(scm, "foo");
-
-        // polling on the slave for the code path that doesn't find any change
-        assertTrue(p.pollSCMChanges(new StreamTaskListener(System.out, Charset.defaultCharset())));
-    }
-
-    /**
      * Tests a checkout triggered from the post-commit hook
      */
     public void testPostCommitTrigger() throws Exception {

--- a/src/test/java/hudson/scm/SubversionSCMTest.java
+++ b/src/test/java/hudson/scm/SubversionSCMTest.java
@@ -32,13 +32,15 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.jvnet.hudson.test.Bug;
 
+import static junit.framework.Assert.assertEquals;
+
 
 /**
  * Test for {@link SubversionSCM}
  * </p>
  * Date: 7/21/11
  *
- * @author
+ * @author Anton Kozak
  */
 @RunWith(Parameterized.class)
 public class SubversionSCMTest {
@@ -62,6 +64,6 @@ public class SubversionSCMTest {
     @Bug(8700)
     @Test
     public void testValidateExcludedUsers() {
-        Assert.assertEquals(expectedResult, SubversionSCM.DescriptorImpl.validateExcludedUser(userName));
+        assertEquals(expectedResult, SubversionSCM.DescriptorImpl.validateExcludedUser(userName));
     }
 }


### PR DESCRIPTION
Fixed HUDSON-8554 SCM polling always return true when using specific revision in svn
