### PR TITLE
Improved fix for HUDSON-4605 (Builds aborted during SVN update are marked as FAILURE)

### DIFF
--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -68,7 +68,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.IOException;
-import java.io.InterruptedIOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.PrintWriter;
@@ -778,7 +777,7 @@ public class SubversionSCM extends SCM implements Serializable {
             this.revisionPolicy = (scm.getDescriptor() != null ? scm.getDescriptor().getRevisionPolicy() : null);
         }
 
-        public List<External> invoke(File ws, VirtualChannel channel) throws IOException {
+        public List<External> invoke(File ws, VirtualChannel channel) throws IOException, InterruptedException {
             manager = createSvnClientManager(authProvider);
             this.ws = ws;
             try {
@@ -788,8 +787,6 @@ public class SubversionSCM extends SCM implements Serializable {
 
                 return externals;
 
-            } catch (InterruptedException e) {
-                throw (InterruptedIOException) new InterruptedIOException().initCause(e);
             } finally {
                 manager.dispose();
             }

--- a/src/main/java/hudson/scm/subversion/CheckoutUpdater.java
+++ b/src/main/java/hudson/scm/subversion/CheckoutUpdater.java
@@ -101,7 +101,7 @@ public class CheckoutUpdater extends WorkspaceUpdater {
                             svnDepth, true);
                 }
             } catch (SVNCancelException e) {
-                listener.error("Svn command was canceled");
+                listener.error("Svn command was aborted");
                 throw (InterruptedException) new InterruptedException().initCause(e);
             } catch (SVNException e) {
                 e.printStackTrace(listener.error("Failed to check out " + location.remote));

--- a/src/main/java/hudson/scm/subversion/UpdateUpdater.java
+++ b/src/main/java/hudson/scm/subversion/UpdateUpdater.java
@@ -134,7 +134,7 @@ public class UpdateUpdater extends WorkspaceUpdater {
                         " ignoreExternals: " + l.isIgnoreExternalsOption());
                     svnuc.doUpdate(local.getCanonicalFile(), revision, svnDepth, true, false);
                 } catch (SVNCancelException e) {
-                    listener.error("Svn command was canceled");
+                    listener.error("Svn command was aborted");
                     throw (InterruptedException) new InterruptedException().initCause(e);
                 } catch (final SVNException e) {
                     if (e.getErrorMessage().getErrorCode() == SVNErrorCode.WC_LOCKED) {


### PR DESCRIPTION
Improved fix for HUDSON-4605 (Builds aborted during SVN update are marked as FAILURE)
