### PR TITLE
Fixed http://java.net/jira/browse/HUDSON-3 SVN fails to checkout in Matrix Jobs in Hudson 2.1.0

### DIFF
--- a/src/main/java/hudson/scm/PerJobCredentialStore.java
+++ b/src/main/java/hudson/scm/PerJobCredentialStore.java
@@ -3,6 +3,7 @@ package hudson.scm;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.XmlFile;
+import hudson.matrix.MatrixConfiguration;
 import hudson.model.AbstractProject;
 import hudson.model.Hudson;
 import hudson.model.Saveable;
@@ -114,8 +115,14 @@ final class PerJobCredentialStore implements Saveable, RemotableSVNAuthenticatio
         }
     }
 
-    private XmlFile getXmlFile() {
-        return new XmlFile(new File(project.getRootDir(), credentialsFileName));
+    XmlFile getXmlFile() {
+        File rootDir;
+        if (project instanceof MatrixConfiguration && project.getParent() != null) {
+            rootDir = project.getParent().getRootDir();
+        } else{
+            rootDir = project.getRootDir();
+        }
+        return new XmlFile(new File(rootDir, credentialsFileName));
     }
 
     /*package*/

--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -1539,7 +1539,7 @@ public class SubversionSCM extends SCM implements Serializable {
         /**
          * See {@link DescriptorImpl#createAuthenticationProvider(AbstractProject)}.
          */
-        private static final class SVNAuthenticationProviderImpl
+        static final class SVNAuthenticationProviderImpl
             implements ISVNAuthenticationProvider, ISVNAuthenticationOutcomeListener, Serializable {
             /**
              * Project-scoped authentication source. For historical reasons, can be null.
@@ -1560,6 +1560,15 @@ public class SubversionSCM extends SCM implements Serializable {
                                                  RemotableSVNAuthenticationProvider global) {
                 this.global = global;
                 this.local = local;
+            }
+
+            /**
+             * For the tests only.
+             *
+             * @return local SVNAuthenticationProvide (PerJobCredentialStore).
+             */
+            RemotableSVNAuthenticationProvider getLocal() {
+                return local;
             }
 
             private SVNAuthentication fromProvider(SVNURL url, String realm, String kind,


### PR DESCRIPTION
Fixed http://java.net/jira/browse/HUDSON-3 SVN fails to checkout in Matrix Jobs in Hudson 2.1.0
