### PR TITLE
hudson-plugin-parent upgraded to the latest hudson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@ THE SOFTWARE.
     <parent>
         <groupId>org.jvnet.hudson.plugins</groupId>
         <artifactId>hudson-plugin-parent</artifactId>
-        <version>2.1.1</version>
+        <version>2.1.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/src/main/java/hudson/scm/SubversionChangeLogParser.java
+++ b/src/main/java/hudson/scm/SubversionChangeLogParser.java
@@ -26,9 +26,8 @@ package hudson.scm;
 import hudson.model.AbstractBuild;
 import hudson.scm.SubversionChangeLogSet.LogEntry;
 import hudson.scm.SubversionChangeLogSet.Path;
-import hudson.util.Digester2;
 import hudson.util.IOException2;
-import org.apache.commons.digester.Digester;
+import org.apache.commons.digester3.Digester;
 import org.xml.sax.SAXException;
 
 import java.io.File;
@@ -44,7 +43,7 @@ public class SubversionChangeLogParser extends ChangeLogParser {
     public SubversionChangeLogSet parse(AbstractBuild build, File changelogFile) throws IOException, SAXException {
         // http://svn.collab.net/repos/svn/trunk/subversion/svn/schema/
 
-        Digester digester = new Digester2();
+        Digester digester = new Digester();
         ArrayList<LogEntry> r = new ArrayList<LogEntry>();
         digester.push(r);
 


### PR DESCRIPTION
Upgraded hudson-plugin-parent to 2.1.2-SNAPSHOT, replaced  Digester2 with org.apache.commons.digester3.Digester.
