### PR TITLE
SVN to fail on workspace lock.

### DIFF
--- a/src/main/java/hudson/scm/DefaultSVNAuthenticationManager.java
+++ b/src/main/java/hudson/scm/DefaultSVNAuthenticationManager.java
@@ -1,5 +1,25 @@
-/**
- * 
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2012, Oracle, Inc., Steven Christou
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
  */
 package hudson.scm;
 

--- a/src/main/java/hudson/scm/SubversionWorkspaceSelector.java
+++ b/src/main/java/hudson/scm/SubversionWorkspaceSelector.java
@@ -29,7 +29,10 @@ import hudson.remoting.Channel;
 import org.tmatesoft.svn.core.SVNException;
 import org.tmatesoft.svn.core.internal.wc.admin.ISVNAdminAreaFactorySelector;
 import org.tmatesoft.svn.core.internal.wc.admin.SVNAdminArea14;
+import org.tmatesoft.svn.core.internal.wc.admin.SVNAdminArea15;
+import org.tmatesoft.svn.core.internal.wc.admin.SVNAdminArea16;
 import org.tmatesoft.svn.core.internal.wc.admin.SVNAdminAreaFactory;
+import org.tmatesoft.svn.core.internal.wc17.db.ISVNWCDb;
 
 import java.io.File;
 import java.io.IOException;
@@ -60,6 +63,11 @@ public class SubversionWorkspaceSelector implements ISVNAdminAreaFactorySelector
         SVNAdminAreaFactory.setUpgradeEnabled(false);
     }
 
+    /**
+     * {@link #getEnabledFactories(File, Collection, boolean)} method is called quite a few times
+     * during a Subversion operation, so consulting this value back with master each time is not practical
+     * performance wise. Therefore, we have {@link SubversionSCM} set this value, even though it's error prone.
+     */
     @SuppressWarnings("unchecked")
     public Collection getEnabledFactories(File path, Collection factories, boolean writeAccess) throws SVNException {
         if(!writeAccess)    // for reading, use all our available factories
@@ -74,12 +82,12 @@ public class SubversionWorkspaceSelector implements ISVNAdminAreaFactorySelector
         return enabledFactories;
     }
 
-    /**
-     * {@link #getEnabledFactories(File, Collection, boolean)} method is called quite a few times
-     * during a Subversion operation, so consulting this value back with master each time is not practical
-     * performance wise. Therefore, we have {@link SubversionSCM} set this value, even though it's error prone.
-     */
-    public static volatile int workspaceFormat = SVNAdminArea14.WC_FORMAT;
+    public static volatile int workingCopyFormat14 = SVNAdminArea14.WC_FORMAT;
+    public static volatile int workingCopyFormat15 = SVNAdminArea15.WC_FORMAT;
+    public static volatile int workingCopyFormat16 = SVNAdminArea16.WC_FORMAT;
+    public static volatile int workingCopyFormat17 = ISVNWCDb.WC_FORMAT_17;
+    
+    public static volatile int workspaceFormat = workingCopyFormat14; // We set the default working copy format to 1.4
 
 	@SuppressWarnings("boxing")
 	public static void syncWorkspaceFormatFromMaster() {

--- a/src/main/java/hudson/scm/credential/SshPublicKeyCredential.java
+++ b/src/main/java/hudson/scm/credential/SshPublicKeyCredential.java
@@ -43,6 +43,8 @@ import org.tmatesoft.svn.core.SVNException;
 import org.tmatesoft.svn.core.auth.ISVNAuthenticationManager;
 import org.tmatesoft.svn.core.auth.SVNSSHAuthentication;
 
+//TODO: Write unit test to validate svn+ssh:// support.
+
 /**
  * Public key authentication for Subversion over SSH.
  * <p/>

--- a/src/main/java/hudson/scm/subversion/SVNEvent.java
+++ b/src/main/java/hudson/scm/subversion/SVNEvent.java
@@ -1,5 +1,25 @@
-/**
- * 
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2012, Oracle, Inc., Steven Christou
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
  */
 package hudson.scm.subversion;
 
@@ -15,7 +35,7 @@ import org.tmatesoft.svn.core.wc.SVNEventAction;
 import org.tmatesoft.svn.core.wc.SVNStatusType;
 
 /**
- * @author Steven
+ * @author Steven Christou
  *
  */
 public class SVNEvent extends org.tmatesoft.svn.core.wc.SVNEvent {

--- a/src/main/java/hudson/scm/subversion/UpdateUpdater.java
+++ b/src/main/java/hudson/scm/subversion/UpdateUpdater.java
@@ -142,8 +142,8 @@ public class UpdateUpdater extends WorkspaceUpdater {
 
                     if (e.getErrorMessage().getErrorCode() == SVNErrorCode.WC_LOCKED) {
                         // work space locked. try fresh check out
-                        listener.getLogger().println("Workspace appear to be locked, so getting a fresh workspace");
-                        return delegateTo(new CheckoutUpdater());
+                        listener.getLogger().println("Workspace appear to be locked, so Failing the build");
+                        throw (InterruptedException) new InterruptedException().initCause(e);
                     }
                     if (e.getErrorMessage().getErrorCode() == SVNErrorCode.WC_OBSTRUCTED_UPDATE) {
                         // HUDSON-1882. If existence of local files cause an update to fail,

--- a/src/main/resources/hudson/scm/SubversionSCM/global.jelly
+++ b/src/main/resources/hudson/scm/SubversionSCM/global.jelly
@@ -30,6 +30,7 @@ THE SOFTWARE.
             <f:option value="8"  selected="${descriptor.workspaceFormat==8}" >1.4</f:option>
             <f:option value="9"  selected="${descriptor.workspaceFormat==9}" >1.5</f:option>
             <f:option value="10" selected="${descriptor.workspaceFormat==10}">1.6 (svn:externals to file)</f:option>
+            <f:option value="29" selected="${descriptor.workspaceFormat==29}">1.7</f:option>
           </select>
         </f:entry>
         <f:entry title="${%Subversion Revision Policy}" help="/descriptor/hudson.scm.SubversionSCM/help/revisionPolicy">


### PR DESCRIPTION
Few changes for this pull request:
1. Updated MIT license header.
2. Updated svn workspace copy version to 1.7
3. If a workspace fails to update due to a locked file, then fail the build rather than fresh checkout. A failed update on a lock occurs when large files are committed at same time as update is being executed. We should wait for the next poll of SCM to do another clean run.
